### PR TITLE
Update example to v13

### DIFF
--- a/website/static/website/example.py
+++ b/website/static/website/example.py
@@ -1,12 +1,12 @@
-from telegram.ext import Updater, CommandHandler
+from telegram import Update
+from telegram.ext import Updater, CommandHandler, CallbackContext
 
 
-def hello(update, context):
-    update.message.reply_text(
-        'Hello {}'.format(update.message.from_user.first_name))
+def hello(update: Update, context: CallbackContext) -> None:
+    update.message.reply_text(f'Hello {update.effective_user.first_name}')
 
 
-updater = Updater('YOUR TOKEN HERE', use_context=True)
+updater = Updater('YOUR TOKEN HERE')
 
 updater.dispatcher.add_handler(CommandHandler('hello', hello))
 

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -11,15 +11,15 @@
   and the highlighted code underneath with
   pygmentize -f html example.py
 {% endcomment %}
-<div class="highlight"><pre><span></span><span class="kn">from</span> <span class="nn">telegram.ext</span> <span class="kn">import</span> <span class="n">Updater</span><span class="p">,</span> <span class="n">CommandHandler</span>
+<div class="highlight"><pre><span></span><span class="kn">from</span> <span class="nn">telegram</span> <span class="kn">import</span> <span class="n">Update</span>
+<span class="kn">from</span> <span class="nn">telegram.ext</span> <span class="kn">import</span> <span class="n">Updater</span><span class="p">,</span> <span class="n">CommandHandler</span><span class="p">,</span> <span class="n">CallbackContext</span>
 
 
-<span class="k">def</span> <span class="nf">hello</span><span class="p">(</span><span class="n">update</span><span class="p">,</span> <span class="n">context</span><span class="p">):</span>
-    <span class="n">update</span><span class="o">.</span><span class="n">message</span><span class="o">.</span><span class="n">reply_text</span><span class="p">(</span>
-        <span class="s1">&#39;Hello {}&#39;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">update</span><span class="o">.</span><span class="n">message</span><span class="o">.</span><span class="n">from_user</span><span class="o">.</span><span class="n">first_name</span><span class="p">))</span>
+<span class="k">def</span> <span class="nf">hello</span><span class="p">(</span><span class="n">update</span><span class="p">:</span> <span class="n">Update</span><span class="p">,</span> <span class="n">context</span><span class="p">:</span> <span class="n">CallbackContext</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
+    <span class="n">update</span><span class="o">.</span><span class="n">message</span><span class="o">.</span><span class="n">reply_text</span><span class="p">(</span><span class="sa">f</span><span class="s1">&#39;Hello </span><span class="si">{</span><span class="n">update</span><span class="o">.</span><span class="n">effective_user</span><span class="o">.</span><span class="n">first_name</span><span class="si">}</span><span class="s1">&#39;</span><span class="p">)</span>
 
 
-<span class="n">updater</span> <span class="o">=</span> <span class="n">Updater</span><span class="p">(</span><span class="s1">&#39;YOUR TOKEN HERE&#39;</span><span class="p">,</span> <span class="n">use_context</span><span class="o">=</span><span class="bp">True</span><span class="p">)</span>
+<span class="n">updater</span> <span class="o">=</span> <span class="n">Updater</span><span class="p">(</span><span class="s1">&#39;YOUR TOKEN HERE&#39;</span><span class="p">)</span>
 
 <span class="n">updater</span><span class="o">.</span><span class="n">dispatcher</span><span class="o">.</span><span class="n">add_handler</span><span class="p">(</span><span class="n">CommandHandler</span><span class="p">(</span><span class="s1">&#39;hello&#39;</span><span class="p">,</span> <span class="n">hello</span><span class="p">))</span>
 


### PR DESCRIPTION
1. drop `use_context=True`, it's no longer needed
2. annotate the `hello` function
3. use f-string b/c v13 dropeed py3.5
4. use `update.effective_user` instead of `updat.message.from_user`

'2. is not strictly necessary, but as type hinting is one of the major additions of v13, I think we should showcase it
3.-4. are even more discussable. `format` still works, but why stick to old syntax? Also `update.message.from_user` is closer to pure API, while on the other hand PTBs motto is "more than a wrapper" …
